### PR TITLE
modify .sidebar-tabs css opacity to 0 and hide .sidebar backround-color.

### DIFF
--- a/docs/css/ol3-sidebar.css
+++ b/docs/css/ol3-sidebar.css
@@ -35,6 +35,7 @@
       right: 6px; } }
 
 .sidebar-tabs {
+  opacity: 0;
   top: 0;
   bottom: 0;
   height: 100%;
@@ -136,8 +137,8 @@
   .sidebar-right .sidebar-close {
     left: 0; }
 
-.sidebar {
-  background-color: rgba(255, 255, 255, 0.4); }
+/* .sidebar {
+  background-color: rgba(255, 255, 255, 0.4); } */
   @media (min-width: 768px) {
     .sidebar {
       border: 3px solid transparent;


### PR DESCRIPTION
這次PR的改動是把sidebar-tabs調整opacity跟註解掉background-color，功能的部分都沒有變動，讓畫面上至少看不到地圖右邊的橫條，請您過目。